### PR TITLE
Make sure the list of categorical features is consistent with actually existing features

### DIFF
--- a/opendataval/dataloader/datasets/datasets.py
+++ b/opendataval/dataloader/datasets/datasets.py
@@ -18,7 +18,7 @@ def load_openml(data_id: int, is_classification=True):
     dataset = fetch_openml(data_id=data_id, as_frame=False)
     category_list = list(dataset["categories"].keys())
     if len(category_list) > 0:
-        category_indices = [dataset["feature_names"].index(x) for x in category_list]
+        category_indices = [dataset["feature_names"].index(x) for x in category_list  if x in dataset["feature_names"]]
         noncategory_indices = [
             i for i in range(len(dataset["feature_names"])) if i not in category_indices
         ]


### PR DESCRIPTION

I traced the problem described in #14 to line 21 in `opendataval/dataloader/datasets/datasets.py`. There, you iterate all categorical features to remove them from the dataset. For some reason, sklearn puts feature names into the list of categorical features that are actually not part of the list. 

### Issue Number
Closes #14 

### Description of all changes

The PR adds a simple check that the feature name is actually present in the list.

### Checks
Ensure the following tasks have been completed
- [ ] ```make install-dev```
- [ ] ```pip-sync requirements-dev.txt```
- [ ] ```make build```
- [ ] ```make format```
- [ ] ```make coverage```
- [x] Confirmed auto merge is valid or will solve all merge conflicts
- [x] Wrote Documentation, Docstrings, comments and tests.
- [x] Put `closes #XXXX` in your comment to auto-close issues or added the issues to the PR.

(I am on Windows, so I don't have make. I ran all tests with Python 3.11 and they all pass. Realistically, the change is very small, so I hope that's fine for you)

Thanks for contributing 🎉!