### PR TITLE
Fix IndexError in csshap.py: Incorrect Indexing Due to Typo

### DIFF
--- a/opendataval/dataval/csshap/csshap.py
+++ b/opendataval/dataval/csshap/csshap.py
@@ -126,7 +126,7 @@ class ClassWiseShapley(DataEvaluator, ModelMixin):
             (self.train_classes == label).nonzero(as_tuple=True)[0],
             (self.train_classes != label).nonzero(as_tuple=True)[0],
             (self.valid_classes == label).nonzero(as_tuple=True)[0],
-            (self.train_classes != label).nonzero(as_tuple=True)[0],
+            (self.valid_classes != label).nonzero(as_tuple=True)[0],
         )
 
     def _compute_class_wise_utility(


### PR DESCRIPTION
### Issue Number
27

### Description of all changes
I encountered an IndexError when running the ClassWiseShapley implementation. The error occurs in the train_data_values method(_get_class_indices)
This is caused by incorrect indexing in the _get_class_indices method. The line for valid_out uses self.train_classes instead of self.valid_classes.

Quick summary
1. Specific change 1: def _get_class_indices(self, label: int) -> tuple[Sequence[int], ...]:
"""Gets indices of train and valid data with and without the specified label."""
return (
(self.train_classes == label).nonzero(as_tuple=True)[0],
(self.train_classes != label).nonzero(as_tuple=True)[0],
(self.valid_classes == label).nonzero(as_tuple=True)[0],
(self.valid_classes != label).nonzero(as_tuple=True)[0], # Corrected line
)

### Checks
Ensure the following tasks have been completed
- [ ] ```make install-dev```
- [ ] ```pip-sync requirements-dev.txt```
- [ ] ```make build```
- [ ] ```make format```
- [ ] ```make coverage```
- [ ] Confirmed auto merge is valid or will solve all merge conflicts
- [ ] Wrote Documentation, Docstrings, comments and tests.
- [ ] Put `closes #XXXX` in your comment to auto-close issues or added the issues to the PR.


Thanks for contributing 🎉!