### PR TITLE
Move tensors onto the same device for `remove_high_low`

### DIFF
--- a/opendataval/experiment/exper_methods.py
+++ b/opendataval/experiment/exper_methods.py
@@ -146,7 +146,7 @@ def remove_high_low(
             **train_kwargs,
         )
         y_hat_valid = valuable_model.predict(x_test).to("cpu")
-        valuable_score = metric(y_test, y_hat_valid)
+        valuable_score = metric(y_test.to("cpu"), y_hat_valid)
         valuable_list.append(valuable_score)
 
         # Removing most valuable samples first


### PR DESCRIPTION
### Issue Number
#16 

### Description of all changes
When doing the remove_high_low experiment on a gpu, the metrics fail because the prediction and target tensors are on different devices. This fixes it by making sure that both are moved to the same device before calling the metrics function.

### Checks
Ensure the following tasks have been completed
- [ ] ```make install-dev```
- [ ] ```pip-sync requirements-dev.txt```
- [ ] ```make build```
- [ ] ```make format```
- [ ] ```make coverage```
- [ ] Confirmed auto merge is valid or will solve all merge conflicts
- [x] Wrote Documentation, Docstrings, comments and tests.
- [x] Put `closes #XXXX` in your comment to auto-close issues or added the issues to the PR.

(I am on Windows, so I don't have make. I ran all tests with Python 3.11 and they all pass. Realistically, the change is very small, so I hope that's fine for you)